### PR TITLE
add optional use for `--databases` keyword

### DIFF
--- a/mysqldump-backup.sh
+++ b/mysqldump-backup.sh
@@ -9,6 +9,11 @@ s3_bucket=${S3_BUCKET}
 s3_access_key=${S3_ACCESS_KEY}
 s3_secret_key=${S3_SECRET_KEY}
 override_hostname=${OVERRIDE_HOSTNAME}
+databases_keyword="--databases"
+
+if [[ "$USE_DATABASES_KEY_WORD" == "no" ]]; then
+  databases_keyword=""
+fi
 
 function log {
 	echo "`date +'%Y%m%d %H%M%S'`: $1"
@@ -44,7 +49,7 @@ for db in $databases; do
 	object="s3://${s3_bucket}/${hostname}/${date}/${filename}"
 
 	log "Dumping database $db"
-	mysqldump --host=$mysql_host --user=$mysql_user --single-transaction --set-gtid-purged=OFF --databases $db | pigz > $tmpfile
+	mysqldump --host=$mysql_host --user=$mysql_user --single-transaction --set-gtid-purged=OFF $databases_keyword $db | pigz > $tmpfile
 	log "Dumping database $db done"
 
 	log "Uploading file $tmpfile to $object"

--- a/mysqldump-backup.sh
+++ b/mysqldump-backup.sh
@@ -9,10 +9,10 @@ s3_bucket=${S3_BUCKET}
 s3_access_key=${S3_ACCESS_KEY}
 s3_secret_key=${S3_SECRET_KEY}
 override_hostname=${OVERRIDE_HOSTNAME}
-databases_keyword="--databases"
+databases_parameter="--databases"
 
-if [[ "$USE_DATABASES_KEY_WORD" == "no" ]]; then
-  databases_keyword=""
+if [[ "$OMIT_DATABASES_PARAMETER" == "true" ]]; then
+  databases_parameter=""
 fi
 
 function log {
@@ -49,7 +49,7 @@ for db in $databases; do
 	object="s3://${s3_bucket}/${hostname}/${date}/${filename}"
 
 	log "Dumping database $db"
-	mysqldump --host=$mysql_host --user=$mysql_user --single-transaction --set-gtid-purged=OFF $databases_keyword $db | pigz > $tmpfile
+	mysqldump --host=$mysql_host --user=$mysql_user --single-transaction --set-gtid-purged=OFF $databases_parameter $db | pigz > $tmpfile
 	log "Dumping database $db done"
 
 	log "Uploading file $tmpfile to $object"


### PR DESCRIPTION
when `--databases` key word is omitted it will create a dump of selected database but without creating "CREATE DATABASE" and "USE " statements
it's helpful to load dump into a different schema in cases like local development or situation where only part of data need to be retrieved. 

It requires to create a database (schema) in target server, as well as point database during recovery. 

caveats:
providing more databases in the same command will not work, as next arguments will be threaten as a table names (this is not a case here)
see https://dev.mysql.com/doc/refman/8.4/en/mysqldump.html#option_mysqldump_databases

